### PR TITLE
Changed pruning algorithm.

### DIFF
--- a/src/Benchmark/Benchmark.php
+++ b/src/Benchmark/Benchmark.php
@@ -89,7 +89,7 @@ class Benchmark
 
     private function standardDeviation(array $data, $mean) {
         $initial = 0;
-        $f = function ($val, $carry) use ($mean) {
+        $f = function ($carry, $val) use ($mean) {
             return $carry + pow($val - $mean, 2);
         };
         $sum = array_reduce($data, $f, $initial);


### PR DESCRIPTION
Currently you are throwing away 20% of your data for no good reason. This PR changes the pruning algorithm from removing the top 10% and bottom 10% to removing values outside of 3 standard deviations from the mean; these values are considered outliers.

I also did some minor formatting cleanup to use `printf` instead of mixing `echo` and `sprintf`.

Note that this also removes the call to `sort`; this is because it is unneeded for the new pruning operation. This may affect the result printer; I am unable to know since I couldn't run tests because my composer install is having issues (globally, not just on your repository). 
