### PR TITLE
Fix microtime usage

### DIFF
--- a/src/Benchmark.php
+++ b/src/Benchmark.php
@@ -84,9 +84,9 @@ class Benchmark implements BenchmarkInterface
         foreach ($this->tests as $test) {
             $testResults = array();
             for ($i = 0; $i < $this->iterations; $i++) {
-                $start = time() + microtime();
+                $start = microtime(true);
                 $test->run($this->parameters);
-                $testResults[] = round((time() + microtime()) - $start, 10);
+                $testResults[] = round(microtime(true) - $start, 10);
             }
 
             $testResults = $this->resultPruner->prune($testResults);


### PR DESCRIPTION
microtime() returns a string with the components of the time and microtime
making the addition to time() redundant and only functional because of
type coercion. In recent versions of php this treated as a E_NOTICE
causing a significant side effect to the obsevation.

After php 5.4 we can fix this by just passing a parameter to microtime to get
the needed float as a return.

https://www.php.net/microtime#refsect1-function.microtime-parameters